### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ CHECK_FD_CLOEXEC([AC_DEFINE(
                   [Whether FD_CLOEXEC is defined.])
                   ])
 
-GDA_BUILDDATE=`date '+%F'`
+GDA_BUILDDATE=`date -u -r ChangeLog '+%F'`
 AC_SUBST(GDA_BUILDDATE, $GDA_BUILDDATE)
 
 dnl **********************


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

And use UTC to be independent of timezones.

Without this patch gda-sql.1 would vary for builds on different days.